### PR TITLE
fix(parser): return fields for nested structs

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Bump version and push tag
       id: tagger
-      uses: anothrNick/github-tag-action@1.36.0
+      uses: anothrNick/github-tag-action@1.52.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true # whether or not to format version as vX.Y.Z

--- a/structs/parser.go
+++ b/structs/parser.go
@@ -155,6 +155,9 @@ func getAttributes(rv reflect.Value, parents []StructAttribute, filterTags, igno
 
 		// Check if the field needs further processing.
 		switch value.Kind() {
+		case reflect.Struct:
+			nestedAttributes := getAttributes(value, append(parents, sa), filterTags, ignoredFields, -1)
+			attributes = append(attributes, nestedAttributes...)
 		case reflect.Slice, reflect.Array:
 			isListOfPrimitives := false
 			newParents := append(parents, sa)

--- a/structs/parser_test.go
+++ b/structs/parser_test.go
@@ -32,9 +32,14 @@ func Test_GetAllAttributes(t *testing.T) {
 		Articles []Article `json:"articles"`
 	}
 
-	type Files struct {
+	type File struct {
 		Dir   *string   `json:"dir"`
 		Paths *[]string `json:"paths"`
+	}
+
+	type SSD struct {
+		Owner Person `json:"owner"`
+		Files []File `json:"files"`
 	}
 
 	var strvalue string
@@ -46,6 +51,20 @@ func Test_GetAllAttributes(t *testing.T) {
 	}
 
 	examples := []Expectation{
+		{
+			Name: "SSD - 1",
+			Model: SSD{
+				Owner: Person{},
+			},
+			Attributes: []string{
+				"owner",
+				"owner.name",
+				"owner.emails",
+				"owner.IsActive",
+				"owner.phones",
+				"files",
+			},
+		},
 		{
 			Name: "Person - 1",
 			Model: Person{
@@ -220,7 +239,7 @@ func Test_GetAllAttributes(t *testing.T) {
 		},
 		{
 			Name: "Files - 1",
-			Model: Files{
+			Model: File{
 				Dir: nil,
 				Paths: &[]string{
 					"/home/users/someone/downloads",
@@ -238,7 +257,7 @@ func Test_GetAllAttributes(t *testing.T) {
 		},
 		{
 			Name: "Files - 2",
-			Model: Files{
+			Model: File{
 				Dir:   nil,
 				Paths: &[]string{},
 			},
@@ -249,7 +268,7 @@ func Test_GetAllAttributes(t *testing.T) {
 		},
 		{
 			Name: "Files - 3",
-			Model: Files{
+			Model: File{
 				Dir:   &strvalue,
 				Paths: &[]string{},
 			},
@@ -260,7 +279,7 @@ func Test_GetAllAttributes(t *testing.T) {
 		},
 		{
 			Name: "Files - 4",
-			Model: Files{
+			Model: File{
 				Dir:   &strvalue,
 				Paths: &[]string{strvalue},
 			},

--- a/structs/struct.go
+++ b/structs/struct.go
@@ -40,7 +40,7 @@ func (sa *StructAttribute) FullName() (name string) {
 	scope := sa.Parents[len(sa.Parents)-1].FullName()
 
 	// Adds the array notation to the slice/array field
-	if sa.ListPosition != -1 {
+	if sa.ListPosition >= 0 {
 		scope = strings.Join([]string{scope, fmt.Sprint("[", sa.ListPosition, "]")}, "")
 	}
 


### PR DESCRIPTION
[chore(workflows): bump tag action](https://github.com/oleoneto/go-structs/commit/76d2c64a47d061ae95a1f702819ddd6cea2ba389)