### PR TITLE
feat: allows JSON type overrides in `Decode()`

### DIFF
--- a/structs/decoder_test.go
+++ b/structs/decoder_test.go
@@ -17,6 +17,12 @@ func Test_Decode(t *testing.T) {
 		Email string  `json:"email" db:"email"`
 	}
 
+	type Generic struct{}
+
+	type Payment struct {
+		Id Generic `json:"id"`
+	}
+
 	type args struct {
 		data    []byte
 		model   any
@@ -186,6 +192,44 @@ func Test_Decode(t *testing.T) {
 				},
 			},
 			want: map[string][]string{"error": {"CUSTOM_ERROR"}},
+		},
+		{
+			name: "json type override - 1",
+			args: args{
+				data:  []byte(`{"id": 0.002}}`),
+				model: &Payment{},
+				options: DecoderOptions{
+					Rules:         []SchemaValidationRule{INVALID_TYPE, REQUIRED_ATTRIBUTE, ADDITIONAL_PROPERTY},
+					JSONOverrides: []JSONTypeOverride{{GoType: "Generic", JSONType: "string"}},
+				},
+			},
+			want: map[string][]string{
+				"id": {"INVALID_TYPE"},
+			},
+		},
+		{
+			name: "json type override - 2",
+			args: args{
+				data:  []byte(`{"id": 0.002}}`),
+				model: &Payment{},
+				options: DecoderOptions{
+					Rules:         []SchemaValidationRule{INVALID_TYPE, REQUIRED_ATTRIBUTE, ADDITIONAL_PROPERTY},
+					JSONOverrides: []JSONTypeOverride{{GoType: "Generic", JSONType: "number"}},
+				},
+			},
+			want: map[string][]string{},
+		},
+		{
+			name: "json type override - 3",
+			args: args{
+				data:  []byte(`{"id": [0.002]}}`),
+				model: &Payment{},
+				options: DecoderOptions{
+					Rules:         []SchemaValidationRule{INVALID_TYPE, REQUIRED_ATTRIBUTE, ADDITIONAL_PROPERTY},
+					JSONOverrides: []JSONTypeOverride{{GoType: "Generic", JSONType: "array"}},
+				},
+			},
+			want: map[string][]string{},
 		},
 	}
 


### PR DESCRIPTION
With this change, `Decode()` can take an optional list of Go types and their respective JSON types which it'll use while decoding the provided payload.

**Motivation:**
By default, Go structs are treated as JSON objects by the jsonschema validator. However, there may be instances when we may want to override the JSON representation of a type. For example, we may have a custom struct that serves as our own abstraction around a numeric type. The type itself may be a bit more complex than a simple `int` or a `float` but, much like Go's built-in types, we may still simply want to transit its underlying value as a number and deal with the specifics of the abstraction at the application or API level.